### PR TITLE
rebuild with openblas on windows.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/63a47e9
-  - https://staging.continuum.io/pbp/fs/dsdp-feedstock/pr6/3f4f01b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/63a47e9
+  - https://staging.continuum.io/pbp/fs/dsdp-feedstock/pr6/3f4f01b

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,7 +10,14 @@ rem this way the package can be used as dependency by python-igraph.
 set "LIBRARY_PREFIX_FWD=%LIBRARY_PREFIX:\=/%"
 set "LIBRARY_LIB_FWD=%LIBRARY_LIB:\=/%"
 set "LIBRARY_INC_FWD=%LIBRARY_INC:\=/%"
-cmake %CMAKE_ARGS% -GNinja ^
+
+if "%blas_impl%"=="openblas" (
+    set "BLAS_CMAKE_FLAGS=-DBLA_VENDOR=OpenBLAS"
+) else (
+    set "BLAS_CMAKE_FLAGS=-DBLA_VENDOR=Intel10_64lp"
+)
+
+cmake %CMAKE_ARGS% %BLAS_CMAKE_FLAGS% -GNinja ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% ^
       -DCMAKE_INSTALL_LIBDIR=%LIBRARY_LIB_FWD% ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,12 +3,18 @@
 set -ex
 system=$(uname -s)
 
+if [ "${blas_impl:-openblas}" = "openblas" ]; then
+  BLAS_CMAKE_FLAGS="-DBLA_VENDOR=OpenBLAS"
+else
+  BLAS_CMAKE_FLAGS="-DBLA_VENDOR=Intel10_64lp"
+fi
+
 mkdir -p build
 pushd build
 
 cmake ${CMAKE_ARGS} -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_PREFIX_PATH=$BUILD_PREFIX \
+    -DCMAKE_PREFIX_PATH="${PREFIX}:${BUILD_PREFIX}" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_INCLUDEDIR=include \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
@@ -23,7 +29,7 @@ cmake ${CMAKE_ARGS} -GNinja \
     -DBUILD_SHARED_LIBS=on \
     -DIGRAPH_ENABLE_LTO=1 \
     -DIGRAPH_ENABLE_TLS=1 \
-    -DBLAS_LIBRARIES="-lopenblas" \
+    ${BLAS_CMAKE_FLAGS} \
     ..
 
 cmake --build . --config Release --target igraph -- -j${CPU_COUNT}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+blas_impl:                # [win]
+  - mkl                   # [win]
+  - openblas              # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
-blas_impl:                # [win]
-  - mkl                   # [win]
-  - openblas              # [win]
+blas_impl:
+  - mkl                        # [(x86 or x86_64) and not osx]
+  - openblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,11 +38,11 @@ requirements:
     - mpir 3.0.0  # [win]
     - openblas {{ openblas }}        # [blas_impl == "openblas"]
     - libopenblas {{ libopenblas }}  # [blas_impl == "openblas"]
-    - intel-openmp 2025.0.0          # [win and blas_impl == "mkl"]
-    - mkl-devel 2025.0.0             # [win and blas_impl == "mkl"]
-    - mkl 2025.0.0                   # [win and blas_impl == "mkl"]
+    - intel-openmp 2025.0.0          # [blas_impl == "mkl"]
+    - mkl-devel 2025.0.0             # [blas_impl == "mkl"]
+    - mkl 2025.0.0                   # [blas_impl == "mkl"]
   run:
-    - {{ pin_compatible('intel-openmp') }}  # [win and blas_impl == "mkl"]
+    - {{ pin_compatible('intel-openmp') }}  # [blas_impl == "mkl"]
     - libopenblas  # [blas_impl == "openblas"]
     - _openmp_mutex  # [linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/clear_pkgconfig_libs_private.patch  # [win]
     
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("igraph", max_pin="x.x") }}
 
@@ -37,12 +37,14 @@ requirements:
     - gmp 6.2.1  # [not win]
     - mpir 3.0.0  # [win]
     - openblas  # [not win]
-    - intel-openmp 2025.0.0  # [win]
-    - mkl-devel 2025.0.0  # [win]
-    - mkl 2025.0.0  # [win]
+    - openblas  # [win and blas_impl == "openblas"]
+    - intel-openmp 2025.0.0  # [win and blas_impl == "mkl"]
+    - mkl-devel 2025.0.0  # [win and blas_impl == "mkl"]
+    - mkl 2025.0.0  # [win and blas_impl == "mkl"]
   run:
-    - {{ pin_compatible('intel-openmp') }}  # [win]
+    - {{ pin_compatible('intel-openmp') }}  # [win and blas_impl == "mkl"]
     - libopenblas  # [not win]
+    - libopenblas  # [win and blas_impl == "openblas"]
     - _openmp_mutex  # [linux]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,15 +36,14 @@ requirements:
     - arpack 3.9.0  # [not win]
     - gmp 6.2.1  # [not win]
     - mpir 3.0.0  # [win]
-    - openblas  # [not win]
-    - openblas  # [win and blas_impl == "openblas"]
-    - intel-openmp 2025.0.0  # [win and blas_impl == "mkl"]
-    - mkl-devel 2025.0.0  # [win and blas_impl == "mkl"]
-    - mkl 2025.0.0  # [win and blas_impl == "mkl"]
+    - openblas {{ openblas }}        # [blas_impl == "openblas"]
+    - libopenblas {{ libopenblas }}  # [blas_impl == "openblas"]
+    - intel-openmp 2025.0.0          # [win and blas_impl == "mkl"]
+    - mkl-devel 2025.0.0             # [win and blas_impl == "mkl"]
+    - mkl 2025.0.0                   # [win and blas_impl == "mkl"]
   run:
     - {{ pin_compatible('intel-openmp') }}  # [win and blas_impl == "mkl"]
-    - libopenblas  # [not win]
-    - libopenblas  # [win and blas_impl == "openblas"]
+    - libopenblas  # [blas_impl == "openblas"]
     - _openmp_mutex  # [linux]
 
 test:


### PR DESCRIPTION
igraph rebuild with openblas variant on windows

**Destination channel:** defaults

### Links

- [PKG-13579](https://anaconda.atlassian.net/browse/PKG-13579) 

### Explanation of changes:

- Bump build number
- Add openblas to build matrix for windows
- Fix build.sh to not link with libopenblas in mkl variants
- Fix openblas/mlk dependencies so they don't mix and match. 


[PKG-13579]: https://anaconda.atlassian.net/browse/PKG-13579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ