### PR TITLE
Explicitly add msvc openmp

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-staging_channel_upload_target: openmp-mutex-rework-4
-
-channels:
-  - https://staging.continuum.io/pbp/openmp-mutex-rework-4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
+staging_channel_upload_target: openmp-mutex-rework-4
+
 channels:
-  - build
+  - https://staging.continuum.io/pbp/openmp-mutex-rework-4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,15 +38,15 @@ requirements:
     - mpir 3.0.0  # [win]
     - openblas {{ openblas }}        # [blas_impl == "openblas"]
     - libopenblas {{ libopenblas }}  # [blas_impl == "openblas"]
+    - libgomp                        # [blas_impl == "openblas" and linux]
     - vcomp14                        # [blas_impl == "openblas" and (win and x86_64)]
-    - libgomp                        # [blas_impl == "mkl" and linux]
     - intel-openmp 2025.0.0          # [blas_impl == "mkl"]
     - mkl-devel 2025.0.0             # [blas_impl == "mkl"]
     - mkl 2025.0.0                   # [blas_impl == "mkl"]
   run:
-    - libgomp                               # [blas_impl == "mkl" and linux]
     - {{ pin_compatible('intel-openmp') }}  # [blas_impl == "mkl"]
     - libopenblas  # [blas_impl == "openblas"]
+    - libgomp      # [blas_impl == "openblas" and linux]
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,10 +39,12 @@ requirements:
     - openblas {{ openblas }}        # [blas_impl == "openblas"]
     - libopenblas {{ libopenblas }}  # [blas_impl == "openblas"]
     - vcomp14                        # [blas_impl == "openblas" and (win and x86_64)]
+    - libgomp                        # [blas_impl == "mkl" and linux]
     - intel-openmp 2025.0.0          # [blas_impl == "mkl"]
     - mkl-devel 2025.0.0             # [blas_impl == "mkl"]
     - mkl 2025.0.0                   # [blas_impl == "mkl"]
   run:
+    - libgomp                               # [blas_impl == "mkl" and linux]
     - {{ pin_compatible('intel-openmp') }}  # [blas_impl == "mkl"]
     - libopenblas  # [blas_impl == "openblas"]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/clear_pkgconfig_libs_private.patch  # [win]
     
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("igraph", max_pin="x.x") }}
 
@@ -38,13 +38,13 @@ requirements:
     - mpir 3.0.0  # [win]
     - openblas {{ openblas }}        # [blas_impl == "openblas"]
     - libopenblas {{ libopenblas }}  # [blas_impl == "openblas"]
+    - vcomp14                        # [blas_impl == "openblas" and (win and x86_64)]
     - intel-openmp 2025.0.0          # [blas_impl == "mkl"]
     - mkl-devel 2025.0.0             # [blas_impl == "mkl"]
     - mkl 2025.0.0                   # [blas_impl == "mkl"]
   run:
     - {{ pin_compatible('intel-openmp') }}  # [blas_impl == "mkl"]
     - libopenblas  # [blas_impl == "openblas"]
-    - _openmp_mutex  # [linux]
 
 test:
   files:


### PR DESCRIPTION
igraph rebuild

**Destination channel:** defaults

### Links

- [PKG-14726](https://anaconda.atlassian.net/browse/PKG-14726) 


### Explanation of changes:

- Bump build number
- Explicitly add the compiler (libgpmp and vcomp) openmp implementations that get linked
- Remove _openmp_mutex it's added via the openmp_impl recipes. 


[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)

[PKG-14726]: https://anaconda.atlassian.net/browse/PKG-14726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ