### PR TITLE
Rebuild against libxml2 2.15.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,9 @@
 blas_impl:
   - mkl                        # [(x86 or x86_64) and not osx]
   - openblas
+libxml2:
+  - 2.15.3
+c_compiler_version:   # [osx]
+  - '22'              # [osx]
+cxx_compiler_version: # [osx]
+  - '22'              # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "igraph" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/igraph/igraph/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 91e23e080634393dec4dfb02c2ae53ac4e3837172bb9047d32e39380b16c0bb0
+  sha256: 969f2d7d22f67e788d8638c9a8c96615f50d7819c08978b3ef4a787bb6daa96c
   patches:
     - patches/0001_remove_safelocale.patch  # [osx]
     # clear the 'Libs.private' of generated igraph.pc file, in order to prevent pkg-config from attempting to link
@@ -15,7 +15,7 @@ source:
     - patches/clear_pkgconfig_libs_private.patch  # [win]
     
 build:
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage("igraph", max_pin="x.x") }}
 


### PR DESCRIPTION
igraph 1.0.1
**Destination channel:**  defaults

### Links

- [PKG-15892](https://anaconda.atlassian.net/browse/PKG-15892) 
- [Upstream repository](https://github.com/igraph/igraph/tree/1.0.1)

### Explanation of changes:
- New version number
- Update libxml2 to newer version


[PKG-15892]: https://anaconda.atlassian.net/browse/PKG-15892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ